### PR TITLE
Use `sodium-react-native` on React Native

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   "browser": {
     "sodium-native": "sodium-javascript"
   },
+  "react-native": {
+    "sodium-native": "sodium-react-native"
+  },
   "browserify": {
     "transform": [
       "./build-scripts/transform.js"


### PR DESCRIPTION
This pull request instructs Metro to pull `sodium-react-native` when bundling `sodium-universal` for React Native. If not installed, Metro will fail with a resolution error.