### PR TITLE
Set worker_threads to false when in browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "prepublish": "./build-scripts/generate.js"
   },
   "browser": {
-    "sodium-native": "sodium-javascript"
+    "sodium-native": "sodium-javascript",
+    "worker_threads": false
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
I have an issue https://github.com/peermaps/peermaps-web/pull/39 where `browserify` used together with `tinyify` blows up because `browserify` can't find the `worker_threads` module.

This works great when you're _only_ using `sodium-javascript`, since it has `worker_threads: false`. But if you're browserifying something with `sodium-universal` which in turn points browserify to `sodium-javascript` then any usage of `worker_threads` blows up with browserify.

I suspect this behavior can be explained by that browserify believes itself to be in the `sodium-universal` context, while actually parsing the code in `sodium-javascript`, where `worker_threads` all of a sudden is no longer false.

Adding `worker_threads: false` to _this_ `package.json` solves the issue.