### PR TITLE
bump `sodium-native` to `5.0.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "sodium-universal",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "description": "Universal wrapper for sodium-javascript and sodium-native working in Node.js and the Browser",
   "main": "index.js",
   "dependencies": {
-    "sodium-native": "^4.0.0"
+    "sodium-native": "^5.0.1"
   },
   "peerDependencies": {
     "sodium-javascript": "~0.8.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sodium-universal",
-  "version": "5.0.0",
+  "version": "4.0.1",
   "description": "Universal wrapper for sodium-javascript and sodium-native working in Node.js and the Browser",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Upgraded to use new native bindings.
API is backwards compatible (no change) but scoped to 5.x for clarity.